### PR TITLE
Remove references to first and last name across Okta code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.2.0
+
+## 30/03/2021
+
+- Remove references to first and last name across Okta code.
+
 # 1.1.1
 
 ## 30/03/2021

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "authorization",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Authorization service for the RW API.",
   "repository": "https://github.com/resource-watch/authorization",
   "main": "index.js",

--- a/src/providers/okta.apple.provider.ts
+++ b/src/providers/okta.apple.provider.ts
@@ -36,9 +36,6 @@ export class OktaAppleProvider extends BaseProvider {
             if (!oktaUser) {
                 logger.info('[OktaAppleProvider] User does not exist');
                 user = await OktaService.createUserWithoutPassword({
-                    firstName: 'RW API',
-                    lastName: 'USER',
-                    name: 'RW API USER',
                     email: jwtToken.email,
                     role: 'USER',
                     apps: [],

--- a/src/providers/okta.facebook.provider.ts
+++ b/src/providers/okta.facebook.provider.ts
@@ -62,11 +62,7 @@ export class OktaFacebookProvider extends BaseProvider {
                 }
 
                 user = await OktaService.createUserWithoutPassword({
-                    ...OktaService.findUserName({
-                        firstName: profile?.firstName,
-                        lastName: profile?.lastName,
-                        name: profile?.displayName,
-                    }),
+                    name: profile?.displayName,
                     email,
                     photo: profile.photos?.length > 0 ? profile.photos[0].value : null,
                     role: 'USER',

--- a/src/providers/okta.google.provider.ts
+++ b/src/providers/okta.google.provider.ts
@@ -31,11 +31,7 @@ export class OktaGoogleProvider extends BaseProvider {
                 }
 
                 user = await OktaService.createUserWithoutPassword({
-                    ...OktaService.findUserName({
-                        firstName: profile?.firstName,
-                        lastName: profile?.lastName,
-                        name: profile?.displayName,
-                    }),
+                    name: profile?.displayName,
                     email,
                     photo: profile.photos?.length > 0 ? profile.photos[0].value : null,
                     role: 'USER',

--- a/src/providers/okta.provider.ts
+++ b/src/providers/okta.provider.ts
@@ -304,17 +304,9 @@ export class OktaProvider extends BaseProvider {
             }
         }
 
-        if (ctx.request.body.firstName && !ctx.request.body.lastName) {
-            return ctx.throw(400, 'lastName required.');
-        }
-
-        if (ctx.request.body.lastName && !ctx.request.body.firstName) {
-            return ctx.throw(400, 'firstName required.');
-        }
-
         try {
             ctx.body = await OktaService.createUserWithoutPassword({
-                ...OktaService.findUserName(ctx.request.body),
+                name: body.name,
                 email: body.email,
                 role: body.role,
                 apps: body.extraUserData.apps,
@@ -422,16 +414,8 @@ export class OktaProvider extends BaseProvider {
 
             logger.info('[OktaProvider] - Creating user');
 
-            if (ctx.request.body.firstName && !ctx.request.body.lastName) {
-                return ctx.throw(400, 'lastName required.');
-            }
-
-            if (ctx.request.body.lastName && !ctx.request.body.firstName) {
-                return ctx.throw(400, 'firstName required.');
-            }
-
             const newUser: IUser = await OktaService.createUserWithoutPassword({
-                ...OktaService.findUserName(ctx.request.body),
+                name: ctx.request.body.name,
                 email: ctx.request.body.email,
                 provider: OktaOAuthProvider.LOCAL,
                 role: 'USER',

--- a/src/services/okta.api.service.ts
+++ b/src/services/okta.api.service.ts
@@ -139,8 +139,6 @@ export default class OktaApiService {
                 profile: {
                     email: payload.email,
                     login: payload.email,
-                    firstName: payload.firstName,
-                    lastName: payload.lastName,
                     displayName: payload.name,
                     provider: payload.provider,
                     origin: payload.origin || '',

--- a/src/services/okta.interfaces.ts
+++ b/src/services/okta.interfaces.ts
@@ -15,8 +15,6 @@ export interface JWTPayload {
 export interface OktaUserProfile {
     login: string;
     email: string;
-    firstName: string;
-    lastName: string;
     displayName: string;
     mobilePhone?: string;
     secondEmail?: string;
@@ -49,9 +47,7 @@ export interface OktaUser {
 export interface OktaCreateUserPayload {
     email: string;
     provider: OktaOAuthProvider;
-    firstName: string;
-    lastName: string;
-    name: string;
+    name?: string;
     origin?: string;
     role?: string;
     apps?: string[];
@@ -62,8 +58,6 @@ export interface OktaCreateUserPayload {
 
 export interface OktaImportUserPayload {
     profile: {
-        firstName: string;
-        lastName: string;
         email: string;
         login: string;
         displayName: string;
@@ -127,8 +121,6 @@ export interface OktaSuccessfulLoginResponse {
             passwordChanged: string;
             profile: {
                 login: string;
-                firstName: string;
-                lastName: string;
                 locale: string;
                 timeZone: string;
             }

--- a/src/views/sign-up.ejs
+++ b/src/views/sign-up.ejs
@@ -65,11 +65,8 @@
                             </div >
                         <% } %>
                         <form action="/auth/sign-up" method="POST" >
-                            <label for="firstName">
-                                <input type="text" name="firstName" placeholder="First Name" required />
-                            </label>
-                            <label for="lastName">
-                                <input type="text" name="lastName" placeholder="Last Name" required />
+                            <label for="name">
+                                <input type="text" name="name" placeholder="Name" />
                             </label>
                             <label for="email">
                                 <input type="email" name="email" placeholder="Email" value="<%= email %>" required />

--- a/test/e2e/okta/okta-import-users.spec.ts
+++ b/test/e2e/okta/okta-import-users.spec.ts
@@ -25,8 +25,6 @@ const mockImportProcess: (user: UserDocument) => void = (user) => {
     const mockBody: OktaImportUserPayload = {
         profile: {
             // Fields expected to always be present
-            firstName: user.name.split(' ')[0],
-            lastName: user.name.split(' ').slice(1).join(' '),
             email: user.email,
             login: user.email,
             displayName: user.name,
@@ -206,8 +204,6 @@ describe('[OKTA] User import test suite', () => {
         nock(config.get('okta.url'))
             .post('/api/v1/users?activate=false', (body) => isEqual(body, {
                 profile: {
-                    firstName: userTwo.name.split(' ')[0],
-                    lastName: userTwo.name.split(' ').slice(1).join(' '),
                     email: userTwo.email,
                     login: userTwo.email,
                     displayName: userTwo.name,
@@ -272,8 +268,6 @@ describe('[OKTA] User import test suite', () => {
         nock(config.get('okta.url'))
             .post('/api/v1/users?activate=false', (body) => isEqual(body, {
                 profile: {
-                    firstName: userTwo.name.split(' ')[0],
-                    lastName: userTwo.name.split(' ').slice(1).join(' '),
                     email: `${userTwo.providerId}@${userTwo.provider}.com`,
                     login: `${userTwo.providerId}@${userTwo.provider}.com`,
                     displayName: userTwo.name,

--- a/test/e2e/okta/okta-oauth-apple.spec.ts
+++ b/test/e2e/okta/okta-oauth-apple.spec.ts
@@ -174,9 +174,6 @@ describe('[OKTA] Apple auth endpoint tests', () => {
         }, []);
 
         mockOktaCreateUser(user, {
-            firstName: 'RW API',
-            lastName: 'USER',
-            name: 'RW API USER',
             email: 'dj8e99g34n@privaterelay.appleid.com',
             provider: OktaOAuthProvider.APPLE,
             photo: null,

--- a/test/e2e/okta/okta-oauth-create-user.spec.ts
+++ b/test/e2e/okta/okta-oauth-create-user.spec.ts
@@ -89,42 +89,6 @@ describe('[OKTA] User management endpoints tests - Create user', () => {
         response.body.errors[0].detail.should.equal('Apps required');
     });
 
-    it('Creating a user with firstName not providing lastName should return 400 Bad Request', async () => {
-        const token: string = mockValidJWT({ role: 'MANAGER' });
-        const response: request.Response = await requester
-            .post(`/auth/user`)
-            .set('Content-Type', 'application/json')
-            .set('Authorization', `Bearer ${token}`)
-            .send({
-                role: 'USER',
-                extraUserData: { apps: ['rw'] },
-                firstName: 'Test',
-            });
-
-        response.status.should.equal(400);
-        response.body.should.have.property('errors').and.be.an('array');
-        response.body.errors[0].status.should.equal(400);
-        response.body.errors[0].detail.should.equal('lastName required.');
-    });
-
-    it('Creating a user with lastName not providing firstName should return 400 Bad Request', async () => {
-        const token: string = mockValidJWT({ role: 'MANAGER' });
-        const response: request.Response = await requester
-            .post(`/auth/user`)
-            .set('Content-Type', 'application/json')
-            .set('Authorization', `Bearer ${token}`)
-            .send({
-                role: 'USER',
-                extraUserData: { apps: ['rw'] },
-                lastName: 'Test',
-            });
-
-        response.status.should.equal(400);
-        response.body.should.have.property('errors').and.be.an('array');
-        response.body.errors[0].status.should.equal(400);
-        response.body.errors[0].detail.should.equal('firstName required.');
-    });
-
     it('Creating an user with an email that already exists in the DB should return 400 Bad Request', async () => {
         const email: string = 'test@example.com';
         const token: string = mockValidJWT({
@@ -175,8 +139,6 @@ describe('[OKTA] User management endpoints tests - Create user', () => {
 
         mockOktaCreateUser(user, {
             email: user.profile.email,
-            firstName: 'Test',
-            lastName: 'User',
             name: 'Test User',
             role: user.profile.role,
             photo: user.profile.photo,
@@ -195,46 +157,6 @@ describe('[OKTA] User management endpoints tests - Create user', () => {
                 email: user.profile.email,
                 photo: user.profile.photo,
                 name: 'Test User',
-            });
-
-        response.status.should.equal(200);
-        response.body.should.be.an('object');
-        response.body.should.have.property('id').and.eql(user.profile.legacyId);
-        response.body.should.have.property('email').and.eql(user.profile.email);
-        response.body.should.have.property('name').and.eql(user.profile.displayName);
-        response.body.should.have.property('role').and.eql(user.profile.role);
-        response.body.should.have.property('extraUserData').and.eql({ apps });
-        response.body.should.have.property('photo').and.eql(user.profile.photo);
-    });
-
-    it('Creating an user with valid data ("firstName" + "lastName") should return 200 OK and the created user data', async () => {
-        const apps: string[] = ['rw'];
-        const token: string = mockValidJWT({ role: 'MANAGER', extraUserData: { apps } });
-        const user: OktaUser = getMockOktaUser({ apps });
-
-        mockOktaCreateUser(user, {
-            email: user.profile.email,
-            firstName: 'Test',
-            lastName: 'User',
-            name: 'Test User',
-            role: user.profile.role,
-            photo: user.profile.photo,
-            apps,
-            provider: OktaOAuthProvider.LOCAL,
-        });
-        mockOktaSendActivationEmail(user);
-
-        const response: request.Response = await requester
-            .post(`/auth/user`)
-            .set('Content-Type', 'application/json')
-            .set('Authorization', `Bearer ${token}`)
-            .send({
-                role: user.profile.role,
-                extraUserData: { apps },
-                email: user.profile.email,
-                photo: user.profile.photo,
-                firstName: 'Test',
-                lastName: 'User',
             });
 
         response.status.should.equal(200);

--- a/test/e2e/okta/okta-oauth-facebook.spec.ts
+++ b/test/e2e/okta/okta-oauth-facebook.spec.ts
@@ -159,8 +159,6 @@ describe('[OKTA] Facebook auth endpoint tests', () => {
 
         mockOktaCreateUser(user, {
             email: 'john.doe@vizzuality.com',
-            firstName: 'John',
-            lastName: 'Doe',
             name: 'John Doe',
             photo: null,
             role: 'USER',

--- a/test/e2e/okta/okta-oauth-google.spec.ts
+++ b/test/e2e/okta/okta-oauth-google.spec.ts
@@ -157,8 +157,6 @@ describe('[OKTA] Google auth endpoint tests', () => {
 
         mockOktaCreateUser(user, {
             email: 'john.doe@vizzuality.com',
-            firstName: 'John',
-            lastName: 'Doe',
             name: 'John Doe',
             photo: null,
             role: 'USER',

--- a/test/e2e/okta/okta-oauth-sign-up-redirect.spec.ts
+++ b/test/e2e/okta/okta-oauth-sign-up-redirect.spec.ts
@@ -59,9 +59,6 @@ describe('[OKTA] OAuth endpoints tests - Sign up with JSON content type', () => 
         const user: OktaUser = getMockOktaUser({ apps: [] });
         mockOktaCreateUser(user, {
             email: user.profile.email,
-            firstName: 'RW API',
-            lastName: 'USER',
-            name: 'RW API USER',
             provider: OktaOAuthProvider.LOCAL,
             role: 'USER',
             origin: 'https://www.google.com',

--- a/test/e2e/okta/okta-oauth-sign-up-with-json-content-type.spec.ts
+++ b/test/e2e/okta/okta-oauth-sign-up-with-json-content-type.spec.ts
@@ -47,9 +47,6 @@ describe('[OKTA] OAuth endpoints tests - Sign up with JSON content type', () => 
         const user: OktaUser = getMockOktaUser({ apps: [] });
         mockOktaCreateUser(user, {
             email: user.profile.email,
-            firstName: 'RW API',
-            lastName: 'USER',
-            name: 'RW API USER',
             provider: OktaOAuthProvider.LOCAL,
             role: 'USER',
         });
@@ -88,9 +85,6 @@ describe('[OKTA] OAuth endpoints tests - Sign up with JSON content type', () => 
         const user: OktaUser = getMockOktaUser({ apps: ['gfw'] });
         mockOktaCreateUser(user, {
             email: user.profile.email,
-            firstName: 'RW API',
-            lastName: 'USER',
-            name: 'RW API USER',
             provider: OktaOAuthProvider.LOCAL,
             role: 'USER',
             apps: ['gfw'],
@@ -118,9 +112,7 @@ describe('[OKTA] OAuth endpoints tests - Sign up with JSON content type', () => 
         const user: OktaUser = getMockOktaUser({ apps: ['gfw'] });
         mockOktaCreateUser(user, {
             email: user.profile.email,
-            firstName: 'RW API',
-            lastName: 'USER',
-            name: 'RW API USER',
+            name: 'Example name',
             provider: OktaOAuthProvider.LOCAL,
             role: 'USER',
             apps: ['gfw'],
@@ -132,6 +124,7 @@ describe('[OKTA] OAuth endpoints tests - Sign up with JSON content type', () => 
             .set('Content-Type', 'application/json')
             .send({
                 email: user.profile.email,
+                name: 'Example name',
                 role: 'ADMIN',
                 apps: user.profile.apps,
             });

--- a/test/e2e/okta/okta.mocks.ts
+++ b/test/e2e/okta/okta.mocks.ts
@@ -18,8 +18,7 @@ import {createTokenForUser} from '../utils/helpers';
 
 export const getMockOktaUser: (override?: Partial<OktaUserProfile>) => OktaUser = (override = {}) => {
     const email: string = faker.internet.email();
-    const firstName: string = faker.name.firstName();
-    const lastName: string = faker.name.lastName();
+    const name: string = `${faker.name.firstName()} ${faker.name.lastName()}`;
     return {
         'id': faker.random.uuid(),
         'status': 'PROVISIONED',
@@ -37,9 +36,7 @@ export const getMockOktaUser: (override?: Partial<OktaUserProfile>) => OktaUser 
             role: 'USER',
             provider: 'okta',
             apps: ['rw'],
-            firstName,
-            lastName,
-            displayName: `${firstName} ${lastName}`,
+            displayName: name,
             photo: faker.image.imageUrl(),
             origin: '',
             ...override,
@@ -81,8 +78,6 @@ export const mockOktaSuccessfulLogin: () => OktaSuccessfulLoginResponse = () => 
                 'passwordChanged': '2020-11-06T16:15:53.000Z',
                 'profile': {
                     'login': faker.internet.email(),
-                    'firstName': faker.name.firstName(),
-                    'lastName': faker.name.lastName(),
                     'locale': 'en',
                     'timeZone': 'America/Los_Angeles'
                 }
@@ -166,8 +161,6 @@ export const mockOktaCreateUser: (user: OktaUser, payload: OktaCreateUserPayload
         .post('/api/v1/users?activate=false', (body) => [
             body.profile.email === payload.email,
             body.profile.login === payload.email,
-            body.profile.firstName === payload.firstName,
-            body.profile.lastName === payload.lastName,
             body.profile.displayName === payload.name,
             body.profile.provider === payload.provider,
             body.profile.origin === payload.origin || body.profile.origin === '',


### PR DESCRIPTION
After making the first and last name optional fields in Okta, we can ditch them altogether from the Authorization service. This way, we map our previous optional `name` field to Okta's optional `displayName` field, keeping everything as before.

This PR also removes all references to "RW API USER", the default placeholder name used before the first and last name requirements.