### PR TITLE
Fix redirect issues in RW with social login

### DIFF
--- a/src/providers/okta.apple.provider.ts
+++ b/src/providers/okta.apple.provider.ts
@@ -7,11 +7,15 @@ import UserSerializer from '../serializers/user.serializer';
 import OktaService from 'services/okta.service';
 import { OktaOAuthProvider, OktaUser, IUser } from 'services/okta.interfaces';
 import OktaProvider from 'providers/okta.provider';
+import Utils from 'utils';
 
 export class OktaAppleProvider {
 
     static async apple(ctx: Context & RouterContext): Promise<void> {
-        const url: string = OktaService.getOAuthRedirect(OktaOAuthProvider.APPLE);
+        const url: string = OktaService.getOAuthRedirect(
+            OktaOAuthProvider.APPLE,
+            `${ctx.protocol}://${Utils.getHostForOAuthRedirect(ctx)}`
+        );
         return ctx.redirect(url);
     }
 

--- a/src/providers/okta.facebook.provider.ts
+++ b/src/providers/okta.facebook.provider.ts
@@ -86,7 +86,10 @@ export class OktaFacebookProvider {
     }
 
     static async facebook(ctx: Context & RouterContext): Promise<void> {
-        const url: string = OktaService.getOAuthRedirect(OktaOAuthProvider.FACEBOOK);
+        const url: string = OktaService.getOAuthRedirect(
+            OktaOAuthProvider.FACEBOOK,
+            `${ctx.protocol}://${Utils.getHostForOAuthRedirect(ctx)}`
+        );
         return ctx.redirect(url);
     }
 

--- a/src/providers/okta.google.provider.ts
+++ b/src/providers/okta.google.provider.ts
@@ -86,7 +86,10 @@ export class OktaGoogleProvider {
     }
 
     static async google(ctx: Context): Promise<void> {
-        const url: string = OktaService.getOAuthRedirect(OktaOAuthProvider.GOOGLE);
+        const url: string = OktaService.getOAuthRedirect(
+            OktaOAuthProvider.GOOGLE,
+            `${ctx.protocol}://${Utils.getHostForOAuthRedirect(ctx)}`
+        );
         return ctx.redirect(url);
     }
 

--- a/src/services/okta.service.ts
+++ b/src/services/okta.service.ts
@@ -354,14 +354,14 @@ export default class OktaService {
         }
     }
 
-    static getOAuthRedirect(provider: OktaOAuthProvider): string {
+    static getOAuthRedirect(provider: OktaOAuthProvider, base: string): string {
         const state: string = uuidv4();
         const oktaOAuthURL: URL = new URL(`${config.get('okta.url')}/oauth2/default/v1/authorize`);
         oktaOAuthURL.searchParams.append('client_id', config.get('okta.clientId'));
         oktaOAuthURL.searchParams.append('response_type', 'code');
         oktaOAuthURL.searchParams.append('response_mode', 'query');
         oktaOAuthURL.searchParams.append('scope', 'openid profile email');
-        oktaOAuthURL.searchParams.append('redirect_uri', `${config.get('server.publicUrl')}/auth/authorization-code/callback`);
+        oktaOAuthURL.searchParams.append('redirect_uri', `${base}/auth/authorization-code/callback`);
         oktaOAuthURL.searchParams.append('idp', config.get(`okta.${provider}IdP`));
         oktaOAuthURL.searchParams.append('state', state);
         return oktaOAuthURL.href;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,6 +4,16 @@ import Settings from 'services/settings.service';
 import { IUser } from 'services/okta.interfaces';
 import { URL } from 'url';
 
+const ALLOW_LIST: string[] = [
+    'localhost:9050',
+    'aws-dev.resourcewatch.org',
+    'aws-staging.resourcewatch.org',
+    'staging-api.resourcewatch.org',
+    'aws-production.resourcewatch.org',
+    'api.resourcewatch.org',
+    'production-api.globalforestwatch.org',
+];
+
 export default class Utils {
 
     static getUser(ctx: Context): IUser {
@@ -95,5 +105,10 @@ export default class Utils {
             return url.host;
         }
         return ctx.request.host;
+    }
+
+    static getHostForOAuthRedirect(ctx: Context): string {
+        const host: string = Utils.getHostForPaginationLink(ctx);
+        return ALLOW_LIST.includes(host) ? host : ctx.host;
     }
 }

--- a/test/e2e/okta/okta-oauth-apple.spec.ts
+++ b/test/e2e/okta/okta-oauth-apple.spec.ts
@@ -120,7 +120,7 @@ describe('[OKTA] Apple auth endpoint tests', () => {
         response.header.location.should.contain(`idp=${config.get('okta.appleIdP')}`);
         response.header.location.should.match(/state=\w/);
 
-        const encodedRedirectUri: string = encodeURIComponent(`${config.get('server.publicUrl')}/auth/authorization-code/callback`);
+        const encodedRedirectUri: string = encodeURIComponent(`http://127.0.0.1:9050/auth/authorization-code/callback`);
         response.header.location.should.contain(`redirect_uri=${encodedRedirectUri}`);
     });
 
@@ -136,7 +136,7 @@ describe('[OKTA] Apple auth endpoint tests', () => {
         response.header.location.should.contain(`idp=${config.get('okta.appleIdP')}`);
         response.header.location.should.match(/state=\w/);
 
-        const encodedRedirectUri: string = encodeURIComponent(`${config.get('server.publicUrl')}/auth/authorization-code/callback`);
+        const encodedRedirectUri: string = encodeURIComponent(`http://127.0.0.1:9050/auth/authorization-code/callback`);
         response.header.location.should.contain(`redirect_uri=${encodedRedirectUri}`);
     });
 
@@ -152,7 +152,7 @@ describe('[OKTA] Apple auth endpoint tests', () => {
         response.header.location.should.contain(`idp=${config.get('okta.appleIdP')}`);
         response.header.location.should.match(/state=\w/);
 
-        const encodedRedirectUri: string = encodeURIComponent(`${config.get('server.publicUrl')}/auth/authorization-code/callback`);
+        const encodedRedirectUri: string = encodeURIComponent(`http://127.0.0.1:9050/auth/authorization-code/callback`);
         response.header.location.should.contain(`redirect_uri=${encodedRedirectUri}`);
     });
 

--- a/test/e2e/okta/okta-oauth-facebook.spec.ts
+++ b/test/e2e/okta/okta-oauth-facebook.spec.ts
@@ -9,19 +9,12 @@ import type request from 'superagent';
 import sinon, {SinonSandbox} from 'sinon';
 import {stubConfigValue} from '../utils/helpers';
 import {
-    getMockOktaUser, mockGetUserByOktaId,
+    getMockOktaUser,
     mockOktaCreateUser,
     mockOktaGetUserByEmail,
-    mockOktaOAuthToken,
     mockOktaSendActivationEmail,
 } from './okta.mocks';
-import {
-    JWTPayload,
-    OktaOAuthProvider,
-    OktaOAuthTokenPayload,
-    OktaSuccessfulOAuthTokenResponse,
-    OktaUser
-} from 'services/okta.interfaces';
+import { JWTPayload, OktaOAuthProvider, OktaUser } from 'services/okta.interfaces';
 
 chai.should();
 
@@ -58,7 +51,7 @@ describe('[OKTA] Facebook auth endpoint tests', () => {
         response.header.location.should.contain(`idp=${config.get('okta.facebookIdP')}`);
         response.header.location.should.match(/state=\w/);
 
-        const encodedRedirectUri: string = encodeURIComponent(`${config.get('server.publicUrl')}/auth/authorization-code/callback`);
+        const encodedRedirectUri: string = encodeURIComponent(`http://127.0.0.1:9050/auth/authorization-code/callback`);
         response.header.location.should.contain(`redirect_uri=${encodedRedirectUri}`);
     });
 
@@ -74,7 +67,7 @@ describe('[OKTA] Facebook auth endpoint tests', () => {
         response.header.location.should.contain(`idp=${config.get('okta.facebookIdP')}`);
         response.header.location.should.match(/state=\w/);
 
-        const encodedRedirectUri: string = encodeURIComponent(`${config.get('server.publicUrl')}/auth/authorization-code/callback`);
+        const encodedRedirectUri: string = encodeURIComponent(`http://127.0.0.1:9050/auth/authorization-code/callback`);
         response.header.location.should.contain(`redirect_uri=${encodedRedirectUri}`);
     });
 
@@ -90,7 +83,7 @@ describe('[OKTA] Facebook auth endpoint tests', () => {
         response.header.location.should.contain(`idp=${config.get('okta.facebookIdP')}`);
         response.header.location.should.match(/state=\w/);
 
-        const encodedRedirectUri: string = encodeURIComponent(`${config.get('server.publicUrl')}/auth/authorization-code/callback`);
+        const encodedRedirectUri: string = encodeURIComponent(`http://127.0.0.1:9050/auth/authorization-code/callback`);
         response.header.location.should.contain(`redirect_uri=${encodedRedirectUri}`);
     });
 

--- a/test/e2e/okta/okta-oauth-google.spec.ts
+++ b/test/e2e/okta/okta-oauth-google.spec.ts
@@ -51,7 +51,7 @@ describe('[OKTA] Google auth endpoint tests', () => {
         response.header.location.should.contain(`idp=${config.get('okta.googleIdP')}`);
         response.header.location.should.match(/state=\w/);
 
-        const encodedRedirectUri: string = encodeURIComponent(`${config.get('server.publicUrl')}/auth/authorization-code/callback`);
+        const encodedRedirectUri: string = encodeURIComponent(`http://127.0.0.1:9050/auth/authorization-code/callback`);
         response.header.location.should.contain(`redirect_uri=${encodedRedirectUri}`);
     });
 
@@ -67,7 +67,7 @@ describe('[OKTA] Google auth endpoint tests', () => {
         response.header.location.should.contain(`idp=${config.get('okta.googleIdP')}`);
         response.header.location.should.match(/state=\w/);
 
-        const encodedRedirectUri: string = encodeURIComponent(`${config.get('server.publicUrl')}/auth/authorization-code/callback`);
+        const encodedRedirectUri: string = encodeURIComponent(`http://127.0.0.1:9050/auth/authorization-code/callback`);
         response.header.location.should.contain(`redirect_uri=${encodedRedirectUri}`);
     });
 
@@ -83,7 +83,7 @@ describe('[OKTA] Google auth endpoint tests', () => {
         response.header.location.should.contain(`idp=${config.get('okta.googleIdP')}`);
         response.header.location.should.match(/state=\w/);
 
-        const encodedRedirectUri: string = encodeURIComponent(`${config.get('server.publicUrl')}/auth/authorization-code/callback`);
+        const encodedRedirectUri: string = encodeURIComponent(`http://127.0.0.1:9050/auth/authorization-code/callback`);
         response.header.location.should.contain(`redirect_uri=${encodedRedirectUri}`);
     });
 


### PR DESCRIPTION
This PR fixes an issue where starting social logins from `api.resourcewatch.org` would redirect users to `production-api.globalforestwatch.org` on success.

It customizes the redirect URL provided to Okta according to the value present in either the referer or host of the request.