### PR TITLE
Handle error message when social login does not provide the email

### DIFF
--- a/src/providers/okta.provider.ts
+++ b/src/providers/okta.provider.ts
@@ -30,8 +30,9 @@ export class OktaProvider {
             const { code, error } = ctx.query;
 
             if (error) {
-                logger.error('[OktaProvider] - Error returned from OAuth authorize call to Okta, ', error);
-                return ctx.redirect('/auth/fail?error=true');
+                const errorDescription: string = ctx.query.error_description as string || '';
+                logger.error('[OktaProvider] - Error returned from OAuth authorize call to Okta, ', error, errorDescription);
+                return ctx.redirect(`/auth/fail?error=true&error_description=${errorDescription}`);
             }
 
             if (!code) {
@@ -386,6 +387,7 @@ export class OktaProvider {
         if (ctx.query.error) {
             await ctx.render('login', {
                 error: true,
+                error_description: ctx.query.error_description || '',
                 thirdParty,
                 generalConfig: ctx.state.generalConfig
             });

--- a/src/views/login.ejs
+++ b/src/views/login.ejs
@@ -61,7 +61,7 @@
                         <h1 >Login</h1 >
                         <% if (error) { %>
                             <div class="callout alert" data-closable >
-                                <p >Email or password invalid</p >
+                                <p><%= error_description && error_description !== '' ? error_description : 'Email or password invalid' %></p >
                                 <button class="close-button" aria-label="Dismiss alert" type="button" data-close >
                                     <span aria-hidden="true" >&times;</span >
                                 </button >

--- a/test/e2e/okta/okta-oauth-authorization-code-callback.spec.ts
+++ b/test/e2e/okta/okta-oauth-authorization-code-callback.spec.ts
@@ -58,6 +58,17 @@ describe('[OKTA] Authorization code callback endpoint tests', () => {
         response.should.redirectTo(new RegExp(`/auth/fail`));
     });
 
+    it('If email is denied access in OAuth login redirects to auth failure page with the error description', async () => {
+        const response: request.Response = await requester
+            .get(`/auth/authorization-code/callback?state=5f6eb362-beb7-4f65-b327-d96199391175&error=access_denied&error_description=Unable+to+process+the+username+transform.+A+required+property+is+missing.+Missing+field%3A+%27email%27.`);
+
+        response.should.redirect;
+        response.redirects[0].should.include('/auth/fail');
+        response.redirects[0].should.include('?error=true');
+        response.redirects[0].should.include('&error_description=Unable%20to%20process%20the%20username%20transform.%20A%20required%20property%20is%20missing.%20Missing%20field:%20%27email%27.');
+        response.text.should.include('Unable to process the username transform. A required property is missing. Missing field: &#39;email&#39;.');
+    });
+
     it('Visiting /auth/authorization-code/callback with a valid OAuth code should redirect to the login successful page', async () => {
         const tokenResponse: OktaSuccessfulOAuthTokenResponse = mockOktaOAuthToken();
         const tokenData: OktaOAuthTokenPayload = JWT.decode(tokenResponse.access_token) as OktaOAuthTokenPayload;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1854,7 +1854,7 @@ fast-levenshtein@^2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
-"fastly-promises@github:tiagojsag/fastly-promises#master":
+fastly-promises@tiagojsag/fastly-promises#master:
   version "0.0.0-semantically-released"
   resolved "https://codeload.github.com/tiagojsag/fastly-promises/tar.gz/14470364f0d4e62b8ff99c8f7e7dd7cb27039242"
   dependencies:


### PR DESCRIPTION
This PR adds a check that if an error description is provided when social login fails, this error description is presented in the UI of the `auth/fail` page.