### PR TITLE
DELETE-endpoint-user-can-request-their-deletion

### DIFF
--- a/src/routes/auth.router.ts
+++ b/src/routes/auth.router.ts
@@ -114,7 +114,7 @@ router.patch('/user/me', Utils.isLogged, OktaProvider.updateMe);
 // @ts-ignore
 router.patch('/user/:id', Utils.isLogged, Utils.isAdmin, OktaProvider.updateUser);
 // @ts-ignore
-router.delete('/user/:id', Utils.isLogged, Utils.isAdmin, OktaProvider.deleteUser);
+router.delete('/user/:id', Utils.isLogged, Utils.isAdminOrSameUserToDelete, OktaProvider.deleteUser);
 
 router.get('/authorization-code/callback', OktaProvider.authCodeCallback, OktaProvider.updateApplications);
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -72,6 +72,23 @@ export default class Utils {
         }
     }
 
+    static async isAdminOrSameUserToDelete(ctx: Context, next: Next): Promise<void> {
+        logger.info('Checking if user is admin or same user to delete');
+        const user: IUser = Utils.getUser(ctx);
+        const userIdToDelete: string = ctx.params.id;
+        if (!user) {
+            logger.info('Not authenticated');
+            ctx.throw(401, 'Not authenticated');
+            return;
+        }
+        if (user.role === 'ADMIN' || user.id === userIdToDelete) {
+            await next();
+        } else {
+            logger.info('Not admin nor same user to be deleted');
+            ctx.throw(403, 'Not authorized');
+        }
+    }
+
     static async isMicroservice(ctx: Context, next: Next): Promise<void> {
         logger.info('Checking if user is a microservice');
         const user: IUser = Utils.getUser(ctx);


### PR DESCRIPTION
-Changes DELETE endpoint to allow users to delete their own account themselves without having to be an ADMIN.
-ADMIN still are able to delete users.
-Adds test for it.